### PR TITLE
Fix broken reading of JSON config for ffmpegloc

### DIFF
--- a/ShowVideoFileProperties.json
+++ b/ShowVideoFileProperties.json
@@ -1,0 +1,3 @@
+{
+	"ffmpegloc": "/usr/local/bin/ffmpeg"
+}

--- a/showvideofileproperties/__init__.py
+++ b/showvideofileproperties/__init__.py
@@ -1,15 +1,9 @@
 from fman import DirectoryPaneCommand, load_json, save_json, show_alert
 from os import stat
-import datetime, re, subprocess, json
+import datetime, re, subprocess
 
 def get_ffmpeg_loc():
-    ffmpegJson = load_json('ShowVideoFileProperties.json')
-    if ffmpegJson:
-        ffmpegloc = json.loads(ffmpegJson)
-        return ffmpegloc['ffmpegloc']
-    else:
-        save_json('ShowVideoFileProperties.json', '{"ffmpegloc": "/usr/local/bin/ffmpeg"}')
-        return "/usr/local/bin/ffmpeg"
+    return load_json('ShowVideoFileProperties.json')['ffmpegloc']
 
 def get_video_size(vpath):
     ffmpegLoc = get_ffmpeg_loc()


### PR DESCRIPTION
When I tried to configure `ffmpeglog` by supplying a `ShowVideoFileProperties.json` file in my `{data directory}/Plugins/User` directory, I received several errors. This PR fixes this and simplifies the code for reading the JSON configuration.